### PR TITLE
Fix legend

### DIFF
--- a/cell2fire/utils/Stats.py
+++ b/cell2fire/utils/Stats.py
@@ -295,13 +295,7 @@ class Statistics(object):
 
         # Create Heatmap
         ax = sns.heatmap(WeightedScar, xticklabels=ticks, yticklabels=ticks, linewidths=0.0, linecolor="w",
-                         square=sq, cmap=tmap, vmin=0.0, vmax=1, annot=False, cbar=False)#cbarF)
-        
-        sm = plt.cm.ScalarMappable(cmap=tmap)#, norm=plt.Normalize(vmin=np.min(0), vmax=np.max(1)))
-        sm._A = []
-        divider = make_axes_locatable(ax)
-        cax1 = divider.append_axes("right", size="5%", pad=0.15)
-        plt.colorbar(sm, cax=cax1)  
+                         square=sq, cmap=tmap, vmin=0.0, vmax=1, annot=False, cbar=False)
 
         # Save it
         if Path is None:
@@ -313,10 +307,10 @@ class Statistics(object):
             spine.set_visible(True)
 
         plt.savefig(os.path.join(Path, namePlot + ".png"), dpi=200, bbox_inches='tight', 
-                    pad_inches=0, transparent=transparent)
+                    pad_inches=1, transparent=transparent)
         if self._pdfOutputs:
             plt.savefig(os.path.join(Path, namePlot + ".pdf"), dpi=200, bbox_inches='tight', 
-                    pad_inches=0, transparent=transparent)
+                    pad_inches=1, transparent=transparent)
         
         
         plt.close("all")
@@ -878,7 +872,7 @@ class Statistics(object):
                 
                 num = str(j+1).zfill(2)
                 self.BPHeatmap(a, Path=PlotPath, nscen=1, sq=True, namePlot="Fire" + num, 
-                               Title="Fire Period " + str(j + 1), cbarF=False, ticks=False,
+                               Title="Fire Period " + str(j + 1), cbarF=True, ticks=False,
                                transparent=True)
             
     

--- a/contributed/delme63/go.bash~
+++ b/contributed/delme63/go.bash~
@@ -1,2 +1,0 @@
-#!/bin/bash
-python main.py --input-instance-folder ../../data/Sub40x40/ --output-folder ../../results/Sub40x40 --ignitions --sim-years 1 --nsims 5 --finalGrid --weather rows --nweathers 1 --Fire-Period-Length 1.0 --output-messages --ROS-CV 0.0 --seed 123 --stats --allPlots --IgnitionRad 5 --grids --combine


### PR DESCRIPTION
Removed legend from fire probability map. Run it with the following command and ensure the pictures look good.

`python main.py --input-instance-folder ../data/Sub40x40/ --output-folder ../results/Sub40x40 --sim-years 2 --nsims 1 --finalGrid --weather random --nweathers 100 --Fire-Period-Length 1.0 --ROS-CV 0.0 --seed 123 --IgnitionRad 0 --stats --output-messages --ROS-Threshold 0 --HFI-Threshold 0 --heuristic 4 --customValue="../data/Sub40x40/values40x40.csv"`