### PR TITLE
added tab 'how to get output figures in readme' to readthedocs

### DIFF
--- a/docsrc/source/conf.py
+++ b/docsrc/source/conf.py
@@ -30,8 +30,7 @@ release = '1.0.0'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-]
+extensions = ['sphinx.ext.autosectionlabel']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docsrc/source/index.rst
+++ b/docsrc/source/index.rst
@@ -19,6 +19,7 @@ This software is for research use only. There is no warranty of any kind; there 
    rstfiles/install.rst
    rstfiles/docker.rst
    rstfiles/run.rst
+   rstfiles/output.rst
    rstfiles/examples.rst
    rstfiles/Editing.rst
    rstfiles/Ig.rst

--- a/docsrc/source/rstfiles/output.rst
+++ b/docsrc/source/rstfiles/output.rst
@@ -1,5 +1,5 @@
 ===================================
-How to Get Output Figures in Readme
+How to Get the Output Figures That Are in Readme
 ===================================
 
 To get the images displayed in `Readme.md <https://github.com/cell2fire/Cell2Fire#output-examples>`__ on the GitHub page, first follow the instructions in :ref:`How to Run Simulator` on the previous page to run the fist command listed. After this is done, the four images displayed below  

--- a/docsrc/source/rstfiles/output.rst
+++ b/docsrc/source/rstfiles/output.rst
@@ -1,0 +1,38 @@
+===================================
+How to Get Output Figures in Readme
+===================================
+
+To get the images displayed in `Readme.md <https://github.com/cell2fire/Cell2Fire#output-examples>`__ on the GitHub page, first follow the instructions in :ref:`How to Run Simulator` on the previous page to run the fist command listed. After this is done, the four images displayed below  
+will be found in the "outputs" file under their respective caption filenames by typing the following command in the terminal:
+
+.. code-block:: html
+   :linenos:
+
+    cd ../outputs
+
+You may then the appropriate command for your operating system to view the images. For example, on a unix machine you would type:
+
+.. code-block:: html
+   :linenos:
+   
+   xdg-open Example4.png
+
+.. figure:: ../../../outputs/Example4.png
+   :width: 40%
+   
+   Dogrib forest (Canadian instance): Example4.png
+
+.. figure:: ../../../outputs/Example1.png
+   :width: 40%
+
+   Visualize shortest paths propagation (10 scens): Example1.png
+
+.. figure:: ../../../outputs/Example2.png
+   :width: 40%
+
+   Shortest paths propagation and ROS intensity (10 scens): Example2.png
+
+.. figure:: ../../../outputs/Example3.png
+   :width: 40%
+   
+   Burn-Probability maps (10 scens): Example3.png


### PR DESCRIPTION
I added an rst file called "output.rst" in for new tab in readthedocs called "How to Get Output Figures in Readme." Also edited index.rst to include the page.
Also added an extension to conf.py to allow for a clickable link referencing another tab.