### PR TITLE
"Fix": `test_20x20` strip for line comparison

### DIFF
--- a/tests/test_20x20.py
+++ b/tests/test_20x20.py
@@ -8,7 +8,7 @@ with --onlyProcessing to avoid calling the compiled C++ code.
 #      be pasted into the github action yml file and here. It should just be in the action
 #      yml file and read here, with --onlyProcessing appended here.
 """
-import  unittest
+import unittest
 import os.path
 import datetime
 from cell2fire.utils.ParseInputs import make_parser
@@ -75,7 +75,7 @@ class TestMain(unittest.TestCase):
         with open(result_path) as result_file:
                 with open(baseline_path) as baseline_file:
                         for line1, line2 in zip(result_file, baseline_file):
-                                                if not line1 == line2:
+                                                if not line1.strip().rstrip(',') == line2.strip().rstrip(',')
                                                         equal = False
                                                         print("In File Grids1/ForestGrid08.csv the result is wrong")
         

--- a/tests/test_20x20.py
+++ b/tests/test_20x20.py
@@ -75,7 +75,7 @@ class TestMain(unittest.TestCase):
         with open(result_path) as result_file:
                 with open(baseline_path) as baseline_file:
                         for line1, line2 in zip(result_file, baseline_file):
-                                                if not line1.strip().rstrip(',') == line2.strip().rstrip(',')
+                                                if not line1.strip().rstrip(',') == line2.strip().rstrip(','):
                                                         equal = False
                                                         print("In File Grids1/ForestGrid08.csv the result is wrong")
         


### PR DESCRIPTION
Similar to #137 

Not really a "fix" as the test was passing as is. This change hedges against trailing commas. 

Both baseline CSVs were updated in #75 (Dec 2020) to include trailing commas. However, the `test_20x20` baseline data was later updated again in commit 60111bf (Apr 2021) which eliminated the trailing commas. This is where the inconsistency arose. 